### PR TITLE
Export constructor for Request

### DIFF
--- a/authn.go
+++ b/authn.go
@@ -76,6 +76,11 @@ type Request struct {
 	request *http.Request
 }
 
+// MakeRequest constructs a Request from an HTTP request.
+func MakeRequest(request *http.Request) Request {
+	return Request{request: request}
+}
+
 // BasicAuth returns the username and password provided in the request's
 // Authorization header, if any.
 func (r Request) BasicAuth() (username string, password string, ok bool) {
@@ -175,7 +180,7 @@ func NewMiddleware(auth AuthFunc, opts ...connect.HandlerOption) *Middleware {
 func (m *Middleware) Wrap(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		ctx := request.Context()
-		info, err := m.auth(ctx, Request{request: request})
+		info, err := m.auth(ctx, MakeRequest(request))
 		if err != nil {
 			_ = m.errW.Write(writer, request, err)
 			return


### PR DESCRIPTION
To allow for better testing of `AuthFuncs` implement a constructor for the `Request` type.

Fixes #8