### PR TITLE
Update go and golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -32,5 +32,5 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -22,36 +20,32 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - copyloopvar       # only valid for go v1.22 and above
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
-    - deadcode          # abandoned
-    - exhaustivestruct  # replaced by exhaustruct
+    - execinquery       # deprecated in golangci v1.58 
+    - exportloopref     # deprecated in golangci v1.60.2
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
-    - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
-    - interfacer        # deprecated by author
+    - gomnd             # deprecated in golangci v1.58 in favor of mnd
+    - mnd               # some unnamed constants are okay
+    - intrange          # only valid for go v1.22 and above
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
     - nlreturn          # generous whitespace violates house style
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
     - testpackage       # internal tests are fine
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
     - nonamedreturns    # named returns help document return types
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
-    - "err113: do not define dynamic errors.*"
+    - "do not define dynamic errors.*"
   exclude-rules:
     # We need to init a global in-mem HTTP server for testable examples.
     - path: examples_test.go

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
 
 $(BIN)/buf: Makefile
 	@mkdir -p $(@D)

--- a/authn_test.go
+++ b/authn_test.go
@@ -24,6 +24,7 @@ import (
 
 	"connectrpc.com/authn"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -50,16 +51,16 @@ func TestMiddleware(t *testing.T) {
 			server.URL+"/empty.v1/GetEmpty",
 			strings.NewReader("{}"),
 		)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		for k, vals := range headers {
 			for _, v := range vals {
 				req.Header.Add(k, v)
 			}
 		}
 		res, err := server.Client().Do(req)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, res.StatusCode, expectCode)
-		assert.Nil(t, res.Body.Close())
+		assert.NoError(t, res.Body.Close())
 	}
 	// Middleware should authenticate non-RPC requests.
 	assertResponse(http.Header{}, http.StatusUnauthorized)
@@ -87,7 +88,7 @@ func assertInfo(ctx context.Context, tb testing.TB) {
 	}
 	name, ok := info.(string)
 	assert.True(tb, ok, "got info of type %T, expected string", info)
-	assert.Equal(tb, name, hero)
+	assert.Equal(tb, hero, name)
 	if id := authn.GetInfo(authn.WithoutInfo(ctx)); id != nil {
 		tb.Fatalf("got info %v after WithoutInfo", id)
 	}


### PR DESCRIPTION
This PR is for maintenance on Go versions and Go-related dependency versions:

* Updates minimum Go version to 1.21
* Updates tested CI versions to 1.21.x, 1.22.x, and 1.23.x
* Updates golangci-lint to v1.60.3 and fixes any lint issues.