### PR TITLE
Add Philip Warren as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,7 @@ Maintainers
 ## Current
 * [Edward McFarlane](https://github.com/emcfarlane), [Buf](https://buf.build)
 * [Josh Humphries](https://github.com/jhump), [Buf](https://buf.build)
+* [Philip Warren](https://github.com/pkwarren), [Buf](https://buf.build)
 
 ## Former
 * [Akshay Shah](https://github.com/akshayjshah)


### PR DESCRIPTION
@pkwarren has been working as a primary contributor to connectrpc libraries. He triages and fixes issues, and is a core collaborator. I'm proposing he is made a maintainer.